### PR TITLE
Fix unquote splicing example

### DIFF
--- a/content/writing-macros.md
+++ b/content/writing-macros.md
@@ -719,7 +719,7 @@ invented exactly for this reason. Unquote splicing is represented by
 ; => (clojure.core/+ (1 2 3))
 
 ;; With unquote splicing
-`(+ ~@(1 2 3))
+`(+ ~@(list 1 2 3))
 ; => (clojure.core/+ 1 2 3)
 ```
 


### PR DESCRIPTION
You forgot the list function in the unquote splicing example.

Thanks for the book!
