### PR TITLE
Fix error in core-functions-in-depth (set -> list)

### DIFF
--- a/content/core-functions-in-depth.md
+++ b/content/core-functions-in-depth.md
@@ -456,7 +456,7 @@ This will work with other data structures as well:
 (into [] (map identity [:garlic :sesame-oil :fried-eggs]))
 ; => [:garlic :sesame-oil :fried-eggs]
 
-;; convert back to set
+;; convert back to list
 (map identity [:garlic-clove :garlic-clove])
 ; => (:garlic-clove :garlic-clove)
 


### PR DESCRIPTION
In 'content/core-functions-in-depth' line 459 it states "convert back to
set" when converting a vector into a list, this is corrected to "convert
back to list".
