### PR TITLE
fixed error in reducers example

### DIFF
--- a/content/concurrency.md
+++ b/content/concurrency.md
@@ -2046,8 +2046,8 @@ you pass `fold` a collection that's not a vector or map, then its
 performance is the same as `reduce`'s:
 
 ```clojure
-;; vector consisting of 1 through 1000000
-(def numbers (vec (range 1000000)))
+;; lazy seq consisting of 1 through 1000000
+(def numbers (range 1000000))
 
 (time (reduce + numbers))
 "Elapsed time: 94.991 msecs"


### PR DESCRIPTION
The text above the example explain that reducers/ fold and reduce operate at the same speed if the collection is NOT of type vector or map. The example however operates on a vector (copied from previous example), I take it that it should be a regular seq instead.
