### PR TITLE
Fix typo in core-functions-in-depth output of unify-diet-data example

### DIFF
--- a/content/core-functions-in-depth.md
+++ b/content/core-functions-in-depth.md
@@ -416,7 +416,7 @@ unifies the two into a single map:
 ; => ({:human 8.1, :critter 0.0}
       {:human 7.3, :critter 0.2}
       {:human 6.6, :critter 0.3}
-      {:human 5.0, :critter 1.8})
+      {:human 5.0, :critter 1.1})
 ```
 
 Good job laying off the human!


### PR DESCRIPTION
Minor typo in the output generated form the unify-diet-data example in
the core-function-in-depth chapter.
