### PR TITLE
Using 'lein new' and not 'lein new app' makes core-async functions not w...

### DIFF
--- a/content/core-async.md
+++ b/content/core-async.md
@@ -66,7 +66,7 @@ machines?
 
 Anyway, enough of my yakking! Let's make these ideas real by creating
 some simple processes. First, create a new Leiningen project called
-"playsync" with `lein new playsync`. Then, open the file `project.clj`
+"playsync" with `lein new app playsync`. Then, open the file `project.clj`
 and add core.async to the `:dependencies` vector so that it reads:
 
 ```clojure


### PR DESCRIPTION
...ork in repl and chapter setup confusing to readers.

Not using the app template means you have to add `:main playsync.core` to the project.clj to have the core.async functions available when you open the repl.

If you use the app template the repl starts in the correct namespace with the core.async functions ready to use.