### PR TITLE
fonts: add Gentium italic, remove unused Oswald

### DIFF
--- a/layouts/default.haml
+++ b/layouts/default.haml
@@ -13,7 +13,7 @@
         | Clojure for the Brave and True
     %link{:href => relative_path_to("/stylesheets/main.css"), :media => "screen", :rel => "stylesheet", :type => "text/css"}/
     %link{:href => relative_path_to("/stylesheets/pygments.css"), :media => "screen", :rel => "stylesheet", :type => "text/css"}/
-    %link{:href => 'http://fonts.googleapis.com/css?family=Oswald:400,300|Gentium+Book+Basic:400,700|Fjalla+One|Courgette', :rel => 'stylesheet', :type => 'text/css'}
+    %link{:href => 'http://fonts.googleapis.com/css?family=Gentium+Book+Basic:400,700,400italic|Fjalla+One|Courgette', :rel => 'stylesheet', :type => 'text/css'}
   %body
     %header
       .container

--- a/layouts/home.haml
+++ b/layouts/home.haml
@@ -11,7 +11,7 @@
       Learn to Program the World's Most Bodacious Language with Clojure for the Brave and True
     %link{:href => relative_path_to("/stylesheets/main.css"), :media => "screen", :rel => "stylesheet", :type => "text/css"}/
     %link{:href => relative_path_to("/stylesheets/pygments.css"), :media => "screen", :rel => "stylesheet", :type => "text/css"}/
-    %link{:href => 'http://fonts.googleapis.com/css?family=Oswald:400,300|Gentium+Book+Basic:400,700|Fjalla+One|Courgette', :rel => 'stylesheet', :type => 'text/css'}
+    %link{:href => 'http://fonts.googleapis.com/css?family=Gentium+Book+Basic:400,700,400italic|Fjalla+One|Courgette', :rel => 'stylesheet', :type => 'text/css'}
   %body
     %header
       .container


### PR DESCRIPTION
I was longing for the beautiful italic of Gentium Book. And I noticed that Oswald is not referenced anywhere and could be removed (unless you had plans for it).