### PR TITLE
Improve readability for narrow viewports

### DIFF
--- a/content/assets/stylesheets/_layout.scss
+++ b/content/assets/stylesheets/_layout.scss
@@ -205,3 +205,21 @@ table {
   @include padding-trailer(.5);
   @include padding-leader(.5);
 }
+
+@media (max-width: 60.5em) {
+  .main, .footer {
+    float: none;
+    width: 100%;
+    margin: auto;
+    > * {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+  }
+  .secondary {
+    display: none;
+  }
+  .code.pygments {
+    overflow: scroll;
+  }
+}


### PR DESCRIPTION
I've made some small tweaks for narrow screens to make it a bit easier to read in a narrow window.

I actually [made a userstyle](https://userstyles.org/styles/121554/) before I realized this repo existed. It works there, but note that I haven't tested specifically here.

<img width="1280" alt="screenshot at 23-07-25" src="https://cloud.githubusercontent.com/assets/721372/11621378/4b7ff244-9c70-11e5-85c6-4f3563277768.png">
<img width="644" alt="screenshot at 23-15-05" src="https://cloud.githubusercontent.com/assets/721372/11621379/4b84053c-9c70-11e5-9419-38fad2777c15.png">