### PR TITLE
Update the output to be correct given the code in the block above

### DIFF
--- a/content/cftbat/appendix-b.html
+++ b/content/cftbat/appendix-b.html
@@ -127,7 +127,7 @@ kind: chapter
 
 <span class="tok-p">(</span><span class="tok-k">def </span><span class="tok-nv">whiney-strinc</span> <span class="tok-p">(</span><span class="tok-nf">whiney-middleware</span> <span class="tok-nb">inc </span><span class="tok-o">#</span><span class="tok-p">{</span><span class="tok-mi">2</span><span class="tok-p">}))</span>
 <span class="tok-p">(</span><span class="tok-nf">whiney-strinc</span> <span class="tok-mi">1</span><span class="tok-p">)</span>
-<span class="tok-c1">; =&gt; "I don't like 2"</span>
+<span class="tok-c1">; =&gt; "I'm not going to bother doing anything to that"</span>
 </code></pre></div></div>
 
 	<ol class="List-1">


### PR DESCRIPTION
when running the following code

```
(defn whiney-middleware
  [next-handler rejects]
  {:pre [(set? rejects)]}
  (fn [x]
     (if (= x 1)
      "I'm not going to bother doing anything to that"
      (let [y (next-handler x)]
        (if (rejects y)
          (str "I don't like " y)
          (str y))))))

(def whiney-strinc (whiney-middleware inc #{2}))
(whiney-strinc 1)
```
i get the output 
`;=>      "I'm not going to bother doing anything to that" `

so i would expect that output in the comment below on the site, but instead I see this:

`; => "I don't like 2"`

It seems like the current comment might be incorrect.