### PR TITLE
Fixed :lat and :lng example outputs in Chapter 3

### DIFF
--- a/content/cftbat/do-things.html
+++ b/content/cftbat/do-things.html
@@ -665,8 +665,8 @@ kind: chapter
   <span class="tok-p">(</span><span class="tok-nb">println </span><span class="tok-p">(</span><span class="tok-nb">str </span><span class="tok-s">"Treasure lng: "</span> <span class="tok-nv">lng</span><span class="tok-p">)))</span>
 
 <span class="tok-p">(</span><span class="tok-nf">announce-treasure-location</span> <span class="tok-p">{</span><span class="tok-ss">:lat</span> <span class="tok-mf">28.22</span> <span class="tok-ss">:lng</span> <span class="tok-mf">81.33</span><span class="tok-p">})</span>
-<span class="tok-c1">; =&gt; Treasure lat: 100</span>
-<span class="tok-c1">; =&gt; Treasure lng: 50</span>
+<span class="tok-c1">; =&gt; Treasure lat: 28.22</span>
+<span class="tok-c1">; =&gt; Treasure lng: 81.33</span>
 </code></pre></div></div>
 
       <p class="Body">Let’s look at the line at ➊ in more detail. This is like telling Clojure, “Yo! Clojure! Do me a flava and associate the name <code>lat</code> with the value corresponding to the key <code>:lat</code>. Do the same thing with <code>lng</code> and <code>:lng</code>, okay?” </p>


### PR DESCRIPTION
Old outputs did not match the inputs.