### PR TITLE
Increased .twitter's z-index

### DIFF
--- a/content/assets/stylesheets/_home.scss
+++ b/content/assets/stylesheets/_home.scss
@@ -144,6 +144,6 @@ $home-hero: (
     position: absolute;
     top: 5px;
     right: 5px;
-    z-index: 1;
+    z-index: 2;
   }
 }


### PR DESCRIPTION
When the z-index is set to 1, the user can't click on the tweet button.